### PR TITLE
Add device compatibility notice and open source contribution section to landing page

### DIFF
--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -102,6 +102,26 @@ function Landing() {
           </svg>
           Get Started with Google
         </button>
+
+        {/* Device compatibility notice */}
+        <div className="mt-8 flex flex-col items-center gap-2">
+          {/* Desktop/tablet message - hidden on mobile */}
+          <div className="hidden sm:flex items-center gap-2 text-sm text-gray-500 bg-white/70 backdrop-blur-sm rounded-full px-4 py-2">
+            <svg className="w-4 h-4 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+            <span>Best experienced on <strong>desktop</strong> and <strong>tablets</strong></span>
+            <span className="text-gray-300">|</span>
+            <span className="text-gray-400">Mobile support coming soon</span>
+          </div>
+          {/* Mobile message - shown only on mobile */}
+          <div className="flex sm:hidden items-center gap-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-full px-4 py-2">
+            <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+            </svg>
+            <span>Mobile support <strong>coming soon</strong> — try us on a desktop or tablet!</span>
+          </div>
+        </div>
       </section>
 
       {/* Features Section */}
@@ -244,6 +264,52 @@ function Landing() {
             </svg>
             Get Started with Google
           </button>
+        </div>
+      </section>
+
+      {/* Open Source Contribution Section */}
+      <section className="bg-gray-900 py-16 border-b border-gray-800">
+        <div className="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8">
+          <div className="inline-flex items-center gap-2 bg-green-900/30 text-green-400 text-sm font-medium rounded-full px-4 py-1.5 mb-6">
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+            </span>
+            Open Source
+          </div>
+          <h3 className="text-3xl font-bold text-white mb-4">
+            Built in the Open. Contribute Today.
+          </h3>
+          <p className="text-lg text-gray-400 mb-8 max-w-2xl mx-auto">
+            iReader is fully open source. Whether you want to fix a bug, add a feature, or improve the docs — jump right in.
+            Every contribution matters.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackEvent('landing_contribute_clicked')}
+              className="inline-flex items-center justify-center gap-2 bg-white hover:bg-gray-100 text-gray-900 font-semibold py-3 px-6 rounded-lg transition-colors"
+            >
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path fillRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clipRule="evenodd" />
+              </svg>
+              View on GitHub
+            </a>
+            <a
+              href={`${GITHUB_REPO_URL}/issues`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackEvent('landing_issues_clicked')}
+              className="inline-flex items-center justify-center gap-2 border border-gray-600 hover:border-gray-400 text-gray-300 hover:text-white font-semibold py-3 px-6 rounded-lg transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+              Browse Open Issues
+            </a>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
- Add responsive device notice in hero section: desktop/tablet users see a subtle
  "best experienced on desktop and tablets" message, while mobile users see an
  amber-styled "coming soon" notice encouraging them to try on a larger screen
- Add open source contribution section before footer with "Built in the Open"
  heading, GitHub repo link, and browse issues CTA to invite developer contributions
- Include PostHog event tracking for new CTAs

https://claude.ai/code/session_01KcmWMoMTDkuPCErq1HcSSV