### PR TITLE
Add sitemap, robots.txt, llms.txt, and SEO meta tags for search engine and AI discoverability

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,67 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="A free, open-source, web-based e-book reader with Kindle-like experience" />
-    <title>iReader - Free E-book Reader</title>
+
+    <!-- SEO Meta Tags -->
+    <title>iReader - Free Open-Source PDF Reader with Cross-Device Sync</title>
+    <meta name="description" content="iReader is a free, open-source web-based PDF reader. Upload, manage, and read your PDFs with infinite scroll, automatic progress tracking, and cross-device sync." />
+    <meta name="keywords" content="PDF reader, ebook reader, web reader, cross-device sync, open source, free PDF reader, online PDF viewer, reading progress" />
+    <link rel="canonical" href="https://ireader-web.vercel.app/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://ireader-web.vercel.app/" />
+    <meta property="og:title" content="iReader - Free Open-Source PDF Reader with Cross-Device Sync" />
+    <meta property="og:description" content="Upload, manage, and read your PDFs with infinite scroll, automatic progress tracking, and cross-device sync. Free and open source." />
+    <meta property="og:image" content="https://ireader-web.vercel.app/screenshots/library.png" />
+    <meta property="og:site_name" content="iReader" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="iReader - Free Open-Source PDF Reader with Cross-Device Sync" />
+    <meta name="twitter:description" content="Upload, manage, and read your PDFs with infinite scroll, automatic progress tracking, and cross-device sync. Free and open source." />
+    <meta name="twitter:image" content="https://ireader-web.vercel.app/screenshots/library.png" />
+
+    <!-- Additional SEO -->
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="iReader Contributors" />
+    <meta name="theme-color" content="#2563eb" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
+
+    <!-- Structured Data (JSON-LD) -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "iReader",
+        "url": "https://ireader-web.vercel.app",
+        "description": "A free, open-source web-based PDF reader with cross-device sync, infinite scroll, and automatic reading progress tracking.",
+        "applicationCategory": "UtilitiesApplication",
+        "operatingSystem": "Any",
+        "browserRequirements": "Requires a modern web browser with JavaScript enabled",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "featureList": [
+          "PDF library management",
+          "Cross-device reading sync",
+          "Automatic progress tracking",
+          "Infinite scroll reader",
+          "Adjustable zoom levels",
+          "Google OAuth sign-in"
+        ],
+        "screenshot": "https://ireader-web.vercel.app/screenshots/library.png",
+        "sourceOrganization": {
+          "@type": "Organization",
+          "name": "iReader Contributors",
+          "url": "https://github.com/vaibhav-bansal/iReader"
+        },
+        "license": "https://opensource.org/licenses/ISC",
+        "isAccessibleForFree": true
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,31 @@
+# iReader
+
+> A free, open-source, web-based PDF reader with cross-device sync and Kindle-like reading experience.
+
+iReader is a modern web application that lets users upload, manage, and read PDF documents in the browser. It provides a distraction-free reading experience with infinite scroll, automatic reading progress tracking, and cross-device synchronization.
+
+## Features
+
+- PDF library management with cover thumbnails
+- Cross-device sync via cloud storage (Supabase)
+- Automatic reading progress tracking
+- Distraction-free reader with adjustable zoom
+- Infinite scroll reading experience
+- Google OAuth authentication
+
+## Tech Stack
+
+- Frontend: React, Vite, Tailwind CSS
+- PDF Rendering: react-pdf (PDF.js)
+- Backend: Supabase (Auth, Database, Storage)
+- State Management: Zustand
+- Data Fetching: TanStack Query
+- Analytics: PostHog, Vercel Analytics
+- Deployment: Vercel
+
+## Links
+
+- Website: https://ireader-web.vercel.app
+- Source Code: https://github.com/vaibhav-bansal/iReader
+- Issues: https://github.com/vaibhav-bansal/iReader/issues
+- License: ISC

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# iReader - Web-based PDF Reader
+# https://github.com/vaibhav-bansal/iReader
+
+User-agent: *
+Allow: /
+Disallow: /library
+Disallow: /reader
+
+Sitemap: https://ireader-web.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ireader-web.vercel.app/</loc>
+    <lastmod>2026-01-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,39 @@
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "framework": "vite",
+  "headers": [
+    {
+      "source": "/robots.txt",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain" }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        { "key": "Content-Type", "value": "application/xml" }
+      ]
+    },
+    {
+      "source": "/llms.txt",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain" }
+      ]
+    }
+  ],
   "rewrites": [
+    {
+      "source": "/robots.txt",
+      "destination": "/robots.txt"
+    },
+    {
+      "source": "/sitemap.xml",
+      "destination": "/sitemap.xml"
+    },
+    {
+      "source": "/llms.txt",
+      "destination": "/llms.txt"
+    },
     {
       "source": "/(.*)",
       "destination": "/index.html"


### PR DESCRIPTION
- Add robots.txt allowing crawlers on public pages, blocking authenticated routes
- Add sitemap.xml with the landing page as the crawlable entry
- Add llms.txt for AI bot discoverability with app description and features
- Enhance index.html with OpenGraph, Twitter Card, JSON-LD structured data, canonical URL, and keywords
- Update vercel.json to serve static SEO files directly before the SPA catch-all rewrite

https://claude.ai/code/session_0162sdkMQk7P7eBwatNGRzU3