### PR TITLE
docs: backfill complete documentation set for v1.0.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,304 @@
+# ReadEz Architecture
+
+This document describes how ReadEz is put together: the pieces, how they talk to each other, and why certain decisions were made. It is aimed at contributors and future-me trying to remember why something is the way it is.
+
+For setup instructions, see [CONTRIBUTING.md](CONTRIBUTING.md). For the API surface, see the routes section below and the Postman collection at [docs/ReadEz.postman_collection.json](docs/ReadEz.postman_collection.json).
+
+## High-level picture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                         Browser                              │
+│                                                              │
+│  React SPA (Vite build)                                      │
+│    • Landing, Library, Reader, Legal, Feedback, Sub*         │
+│    • react-pdf / pdfjs-dist for rendering                    │
+│    • Zustand for ephemeral state, TanStack Query for server  │
+│    • PostHog for analytics (optional)                        │
+└───────────────────────────────┬──────────────────────────────┘
+                                │ fetch(credentials: 'include')
+                                │ cookies: SESSION_COOKIE_NAME
+                                ▼
+┌──────────────────────────────────────────────────────────────┐
+│                 FastAPI backend (uvicorn)                    │
+│                                                              │
+│  Routers:  /auth  /books  /progress  /subscription           │
+│            /payments  /feedback  /webhooks  /health          │
+│                                                              │
+│  Middleware:                                                 │
+│    • CORS (allows FRONTEND_URL with credentials)             │
+│    • SPA middleware (serves index.html for non-API 404s      │
+│      when STATIC_DIR exists — production only)               │
+│                                                              │
+│  Services:                                                   │
+│    • StorageService (local disk, signed URLs)                │
+└────────┬────────────────────────────────┬────────────────────┘
+         │                                │
+         ▼                                ▼
+ ┌───────────────┐              ┌──────────────────┐
+ │  PostgreSQL   │              │   Local disk     │
+ │  (asyncpg)    │              │   storage/books/ │
+ │               │              │   storage/thumb… │
+ │   users       │              │                  │
+ │   sessions    │              │   Signed URLs    │
+ │   books       │              │   for access     │
+ │   reading_…   │              └──────────────────┘
+ │   subscripts  │
+ │   payments    │                       ▲
+ │   feedback    │                       │
+ └───────┬───────┘              ┌────────┴────────┐
+         │                      │  Dodo Payments  │
+         │                      │   (webhooks)    │
+         │                      └─────────────────┘
+         ▼
+   Google OAuth
+   (token exchange)
+```
+
+Two deploy shapes exist today:
+
+- **Single-container** (Railway, via `Dockerfile`) — the Vite build is copied into the FastAPI image and served as static files. One process, one URL.
+- **Split** (Vercel frontend + separate backend) — the `vercel.json` file configures the frontend-only path. The backend runs elsewhere and the frontend calls it with absolute URLs.
+
+The code is written so both shapes work without a rebuild.
+
+## Frontend
+
+### Stack
+
+- **React 19** with function components and hooks
+- **Vite 7** for dev server and build
+- **React Router 7** for routing (`BrowserRouter`)
+- **Tailwind CSS 4** for styling
+- **Zustand 5** for client state that should survive route changes (see `src/store/progressStore.js`)
+- **TanStack Query 5** for server data (books, reading progress, subscription status)
+- **react-pdf 10** (`pdfjs-dist`) for PDF rendering
+- **react-dropzone** for upload UX
+- **react-hot-toast** for notifications
+- **react-infinite-scroll-component** for the reader's page-by-page loading
+- **PostHog JS** for product analytics (optional)
+
+### Routes
+
+Defined in [src/App.jsx](src/App.jsx):
+
+| Path | Component | Auth | Notes |
+|---|---|---|---|
+| `/` | `Landing` | Public | Marketing page |
+| `/legal` | `Legal` | Public | Terms + Privacy |
+| `/feedback` | `Feedback` | Public | Anyone can submit feedback |
+| `/library` | `Library` | Required | List of user's books |
+| `/library/:bookId` | `Reader` | Required | The reading experience — **lazy-loaded** to keep the initial bundle small |
+| `/subscription/success` | `SubscriptionSuccess` | Required | Post-checkout return |
+| `/subscription/cancel` | `SubscriptionCancel` | Required | Post-checkout return |
+| `/reader/:bookId` | redirect → `/library/:bookId` | — | Backward-compat for old URLs |
+| `*` | redirect → `/` | — | 404 fallback |
+
+The `Auth` component in `src/components/Auth.jsx` is the gate: it hits `GET /auth/status`, and either renders children or redirects to the landing page with a prompt to sign in.
+
+### State management
+
+We split state into three layers:
+
+1. **Ephemeral UI state** — `useState` and `useReducer` inside components.
+2. **Client state that crosses routes** — Zustand. Currently just `src/store/progressStore.js` for the reader's in-memory progress buffer (debounced before it hits the server).
+3. **Server state** — TanStack Query. Every call to the ReadEz API goes through `src/lib/api.js`, which TanStack wraps for caching, revalidation, and mutation hooks.
+
+The rule of thumb: if the data lives on the server, use TanStack Query and do not mirror it in Zustand. If you need to pass state between components that are not siblings, use Zustand.
+
+### The reader
+
+`src/pages/Reader.jsx` is the most complex component in the app. It does several things:
+
+- **Signed URL fetch.** On load, it calls `GET /books/{id}/signed-url` to get a short-lived URL for the PDF.
+- **Base64 data fetch.** It then calls `GET /books/{id}/data`, which returns a base64-encoded JSON payload instead of a raw PDF file. This bypasses download managers (IDM, etc.) that would otherwise intercept a `.pdf` response and try to save it to disk.
+- **Blob URL.** The base64 is decoded to a `Blob` and handed to react-pdf as an object URL.
+- **Infinite scroll.** Pages render on demand as the user scrolls. `react-infinite-scroll-component` drives the loading.
+- **Navigation.** Keyboard (`←` / `→` / `Space` / `Home` / `End` / `g`), touch/swipe on mobile, and a page jump modal.
+- **Zoom.** Dynamic fit-to-height calculation based on viewport, with manual zoom controls on top.
+- **Progress tracking.** `currentPage`, scroll position within the current page, and zoom level are captured on every interaction and written to the backend via a 500 ms debounce. This prevents a hundred requests per minute during fast scrolling.
+- **Progress restore.** On first mount, progress is fetched from the server and the reader jumps to the saved position exactly once — guarded by `hasRestoredRef` so a re-render does not re-restore and fight the user.
+
+### PDF.js worker
+
+`pdfjs-dist` needs its worker script in the served assets. The `scripts/copy-worker.js` file runs as a `postinstall` hook and copies the worker into `public/` so Vite can serve it. If the worker is missing, react-pdf throws a "Setting up fake worker" error and pages never render.
+
+### Analytics
+
+`src/lib/posthog.js` initializes PostHog if `VITE_POSTHOG_KEY` is set, and no-ops otherwise. Event names are centralized; add new ones in that file rather than calling `posthog.capture()` inline. The full event catalog lives in [docs/POSTHOG_EVENTS.md](docs/POSTHOG_EVENTS.md).
+
+## Backend
+
+### Stack
+
+- **FastAPI** with async endpoints
+- **SQLAlchemy 2.x** async ORM with **asyncpg** driver
+- **Pydantic v2** for request/response schemas, via `pydantic-settings` for env configuration
+- **httpx** for outbound HTTP (Google OAuth token exchange, Dodo API calls)
+- **pypdf** for extracting page counts from uploaded PDFs
+- **aiofiles** for async disk I/O in the storage service
+- **python-jose** for JWT decoding (Google `id_token`)
+
+### Entry point
+
+`backend/app/main.py` wires everything up:
+
+1. Configures logging.
+2. Builds the FastAPI instance with a `lifespan` context manager that runs `init_db()` on startup.
+3. Adds CORS middleware, allowing credentials from `FRONTEND_URL`.
+4. Registers routers under their prefixes: `/auth`, `/books`, `/progress`, `/subscription`, `/payments`, `/feedback`, `/webhooks`. Plus a top-level `/health` for Railway's healthcheck.
+5. If `/app/static` exists (production container build), mounts `/assets` as static files and installs SPA fallback middleware that serves `index.html` on any non-API 404.
+
+The SPA fallback is middleware rather than a catch-all route because a route would shadow the `/health` check and cause Railway to fail startup.
+
+### Routers
+
+| Prefix | File | Purpose |
+|---|---|---|
+| `/auth` | `backend/app/routes/auth.py` | Google OAuth login, callback, logout, current user, status |
+| `/books` | `backend/app/routes/books.py` | Upload, list, get, delete, thumbnail, signed URLs, data delivery, page count backfill |
+| `/progress` | `backend/app/routes/progress.py` | Get / update reading progress per book |
+| `/subscription` | `backend/app/routes/subscription.py` | Get active subscription + usage, create checkout |
+| `/payments` | `backend/app/routes/payments.py` | Payment history |
+| `/webhooks` | `backend/app/routes/webhooks.py` | Dodo subscription, payment, refund events |
+| `/feedback` | `backend/app/routes/feedback.py` | User feedback submissions |
+| `/health` | `main.py` | Unauthenticated healthcheck |
+
+### Key API endpoints
+
+A subset; see the Postman collection for the complete list.
+
+**Auth:**
+
+- `GET /auth/google/login` — returns `{ authorization_url }`, sets an `oauth_state` cookie (10 min, HttpOnly, Secure, SameSite=Lax) containing the PKCE state and verifier.
+- `GET /auth/google/callback` — validates state, exchanges the code using PKCE S256, decodes the `id_token` JWT (trusted from Google HTTPS), upserts the user, creates a session, sets the session cookie, and returns an HTML page that posts a message to the parent window.
+- `GET /auth/me` — current user.
+- `GET /auth/status` — `{ authenticated: bool, user?: {...} }`, used by the frontend to gate routes.
+- `POST /auth/logout` — deletes the session row and clears the cookie.
+
+**Books:**
+
+- `GET /books` — list current user's books, newest first.
+- `POST /books` — multipart upload of a `.pdf` (max 100 MB). Extracts `total_pages` via `pypdf`, writes to `storage/books/{user_id}/{timestamp}.pdf`, creates a `Book` row and a matching `ReadingProgress` row.
+- `GET /books/{id}/signed-url` — returns `{ url, expires_at }` where the URL is HMAC-signed against `SESSION_SECRET_KEY`.
+- `GET /books/{id}/data?signature=…&expires=…` — returns `{ data: "base64…" }` to bypass download managers.
+- `GET /books/{id}/file?signature=…&expires=…` — raw PDF response with `Content-Disposition: inline`.
+- `POST /books/{id}/thumbnail` — upload a custom thumbnail (used by the frontend-generated first-page preview).
+- `GET /books/{id}/thumbnail` — public, 24-hour cache.
+- `PATCH /books/{id}/page-count` — lazy backfill if an older upload is missing a page count.
+
+**Webhooks:**
+
+- `POST /webhooks/subscription` — subscription created, renewed, cancelled, expired.
+- `POST /webhooks/payment` — payment succeeded or failed.
+- `POST /webhooks/refund` — refund issued.
+
+All three verify the HMAC-SHA256 signature per the [Standard Webhooks](https://www.standardwebhooks.com) spec: `HMAC_SHA256(base64_decode(secret), "{webhook_id}.{webhook_timestamp}.{body}")`. The `whsec_` prefix on the secret is stripped before decoding. If the secret is not configured, verification is skipped (development convenience — never do this in production).
+
+### Data model
+
+All models live under `backend/app/models/`.
+
+**User** (`user.py`)
+- `id` UUID (pk), `email` (unique, indexed), `google_id` (unique, indexed), `name`, `avatar_url`, `created_at`, `updated_at`
+- Cascades to sessions, books, reading_progress, subscription, payments, subscription_usage, feedback
+
+**Session** (`session.py`)
+- `id` UUID (pk), `user_id` FK, `token`, `user_agent`, `ip_address`, `expires_at`, `created_at`
+
+**Book** (`book.py`)
+- `id`, `user_id` FK, `title`, `file_name`, `file_path`, `file_size`, `total_pages` (nullable), `thumbnail_path` (nullable), timestamps
+- One-to-one with `ReadingProgress` (cascade delete)
+
+**ReadingProgress** (`book.py`)
+- `id`, `user_id` FK, `book_id` FK (unique together with `user_id`), `current_page`, `scroll_position`, `zoom_level`, `last_read_at`, `updated_at`
+- The `(user_id, book_id)` uniqueness guarantees exactly one progress row per book per user.
+
+**Subscription** (`subscription.py`)
+- `id`, `user_id` FK (unique — one sub per user), `tier` (`free` / `pro` / `plus`), `status` (`active` / `cancelled` / `expired` / `trialing`), `dodo_subscription_id` (unique), `dodo_customer_id`, `current_period_start`, `current_period_end`, `cancel_at_period_end`, timestamps
+
+**Payment** (`subscription.py`)
+- `id`, `user_id` FK, `subscription_id` FK (SET NULL on delete), `dodo_payment_id` (unique), `dodo_invoice_id`, `dodo_refund_id`, `amount` (cents), `currency`, `status`, `refund_amount`, `refunded_at`, `paid_at`, `webhook_data` (full payload), `created_at`
+
+**SubscriptionUsage** (`subscription.py`)
+- `id`, `user_id` FK, `feature` (`ai_summaries`, `storage_bytes`, etc.), `usage_count`, `reset_at` (for monthly resets), `updated_at`
+
+**Feedback** (`feedback.py`)
+- `id`, `user_id` FK (nullable — anonymous feedback allowed), `message`, `metadata`, `created_at`
+
+### Migrations
+
+The project uses a **lightweight, hand-rolled migration system** under `backend/migrations/`, not Alembic. Initial schema creation happens in `init_db()` via `Base.metadata.create_all()`. Explicit migrations (like `add_payment_external_ids.py`) are one-off Python scripts you run manually.
+
+This is a deliberate choice for a small project. When the schema starts changing frequently or contributors multiply, switching to Alembic will be straightforward.
+
+### Storage service
+
+`backend/app/services/storage.py` wraps local disk access:
+
+- Files are stored under `STORAGE_PATH/books/{user_id}/{unix_ms}.pdf`. Using a timestamp instead of the original filename prevents collisions and avoids leaking the user's naming habits.
+- Signed URLs are HMAC-SHA256 tokens over `{book_id}|{user_id}|{expires_at}` with `SESSION_SECRET_KEY` as the key. Default TTL is short (minutes) — long enough for a page load, short enough to prevent link-sharing.
+- Thumbnails live under `STORAGE_PATH/thumbnails/` and are served from a public endpoint with 24-hour cache.
+
+**Note:** local disk is fine for a single-instance Railway deploy. If you scale to multiple replicas, this needs to move to object storage (S3, R2, etc.) — the interface is already isolated in `StorageService` so the swap is contained.
+
+## Request flows
+
+### Sign-in
+
+1. Frontend opens a popup to `GET /auth/google/login` in a new window.
+2. Backend generates PKCE verifier + challenge, stores them in an `oauth_state` cookie, returns `{ authorization_url }`.
+3. Popup redirects to Google, user approves, Google redirects to `GET /auth/google/callback?code=…&state=…`.
+4. Backend validates state against the cookie, exchanges the code for tokens using the stored PKCE verifier, decodes the `id_token`, upserts the user, creates a `Session` row with `user_agent` and `ip_address`, sets the session cookie.
+5. Callback returns an HTML page that calls `window.opener.postMessage(...)` and closes itself. The parent window sees the message and refreshes its auth state.
+
+### PDF upload
+
+1. User drops a file on the library page. `react-dropzone` validates `.pdf` and size locally.
+2. Frontend `POST /books` with multipart form data. Session cookie travels with the request.
+3. Backend validates again, reads the file, runs `pypdf.PdfReader` to count pages, writes to disk, creates the `Book` row, flushes it (so the FK is valid), then creates the `ReadingProgress` row.
+4. Response: the new book record including `id`, `total_pages`, and a `thumbnail_url` if one already exists.
+5. The frontend optionally generates a first-page thumbnail client-side and uploads it via `POST /books/{id}/thumbnail`.
+
+### Reading
+
+1. User navigates to `/library/:bookId`. React Router lazy-loads the Reader bundle.
+2. Reader calls `GET /books/{id}` (metadata + saved progress) and `GET /books/{id}/signed-url`.
+3. Reader calls `GET /books/{id}/data?signature=…` with the signed URL; backend verifies the HMAC and expiry, returns `{ data: base64 }`.
+4. Frontend decodes to `Blob`, creates an object URL, passes to react-pdf.
+5. As the user scrolls, zooms, or jumps pages, a debounced `PATCH /progress/{book_id}` fires every 500 ms.
+
+### Subscription upgrade
+
+1. User clicks "Upgrade" in the subscription modal.
+2. Frontend calls `POST /subscription/checkout` (or uses Dodo's client SDK directly with the configured product ID).
+3. User is redirected to Dodo checkout.
+4. On completion, Dodo posts to `/webhooks/subscription` with the new subscription details. Backend verifies the HMAC, upserts the `Subscription` row, updates the user's tier.
+5. Dodo redirects the user to `/subscription/success`.
+6. Frontend refetches subscription state via TanStack Query and renders the new badge.
+
+## Deployment
+
+### Railway (single container)
+
+`railway.toml` points at the `Dockerfile`. The Dockerfile is a two-stage build:
+
+1. **Stage 1: frontend-builder.** `node:20-alpine`, installs Python 3 (needed for `pdfjs-dist` native compilation), runs `npm ci` and `npm run build`. Outputs `dist/`.
+2. **Stage 2: runtime.** `python:3.11-slim`, installs `libpq-dev` + `gcc`, `pip install -r backend/requirements.txt`, copies `backend/` and the `dist/` output into `/app/static/`, creates `/app/storage/{books,thumbnails}`, starts `uvicorn app.main:app --host 0.0.0.0 --port $PORT`.
+
+Railway's `PORT` env variable is respected. The healthcheck path is `/health` with a 300-second timeout and up to 3 restart retries.
+
+Postgres URLs from Railway come as `postgresql://…`; the backend rewrites that to `postgresql+asyncpg://…` at startup so SQLAlchemy picks the right driver.
+
+### Vercel (frontend only)
+
+`vercel.json` configures a frontend-only deploy: `vite` framework, `dist` output, and rewrites for the SEO files (`robots.txt`, `sitemap.xml`, `llms.txt`, `humans.txt`, `ai.txt`, `.well-known/security.txt`) plus a catch-all rewrite to `index.html` for SPA routing. The backend needs to run separately and be reachable via CORS when using this deploy shape.
+
+## Things worth knowing
+
+- **Base64 data delivery is intentional.** Returning the PDF as JSON-encoded base64 looks inefficient, but it bypasses download managers like IDM that intercept `Content-Type: application/pdf` responses. If you "optimize" this back to a raw file response, users on Windows with IDM installed will lose the reading experience.
+- **`init_db` creates tables but does not alter them.** Schema changes require a migration script. Do not rely on model edits propagating automatically on restart.
+- **The session cookie is HttpOnly.** JavaScript cannot read it. All requests from the frontend use `credentials: 'include'` via the API client in `src/lib/api.js`.
+- **Dodo webhook secrets come in three flavors** (subscription, payment, refund) for each environment (test, live). Six secrets total. See [backend/.env.example](backend/.env.example).
+- **The reader is lazy-loaded.** Importing `pdfjs-dist` at the top level would blow up the landing page bundle. Keep the lazy boundary.
+- **The `scripts/copy-worker.js` postinstall hook is load-bearing.** If it fails, the reader breaks with a confusing "fake worker" error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to ReadEz are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Nothing yet.
+
+## [1.0.0] - 2026-04-13
+
+First tagged release. This entry backfills the feature history from the repository's initial commits in December 2025 through April 2026. Prior to 1.0.0 there were no version tags, so everything below is grouped by theme rather than individual sub-versions.
+
+### Reading experience
+
+- Infinite-scroll PDF reader with single-page centered layout, keyboard navigation (arrow keys, space, Home/End, `g` for page jump), and touch/swipe gestures on mobile.
+- Dynamic zoom with fit-to-height calculation based on viewport size.
+- Automatic cross-device reading progress sync. Current page, scroll position within a page, and zoom level persist per book, per user.
+- Lazy-loaded Reader route to keep the initial bundle small (PDF.js is heavy).
+- PDF page count extraction on upload, with a lazy backfill path for books uploaded before the feature landed.
+- Book cover thumbnails generated from the first page of each PDF, with a dedicated upload endpoint for user-supplied covers.
+- Reading progress shown on the library page (current page / total pages).
+
+### Accounts and auth
+
+- Google OAuth 2.0 sign-in using PKCE (S256) and the popup flow with `postMessage` handoff.
+- Server-side sessions stored in Postgres with HttpOnly, Secure, SameSite=Lax cookies and a 30-day default lifetime.
+- `GET /auth/me` and `GET /auth/status` endpoints for frontend session hydration.
+- Automatic account linking: existing users signing in with a new Google account get their `google_id` linked to the matching email.
+
+### Subscriptions and payments (Dodo Payments)
+
+- Free / Pro / Plus tier system with per-feature usage tracking (`SubscriptionUsage` model).
+- Dodo Payments checkout integration for Pro and Plus tiers.
+- Webhook handlers for subscription, payment, and refund events, verified using the Standard Webhooks HMAC-SHA256 spec.
+- Separate test and live credentials for Dodo, selected automatically based on `ENVIRONMENT`.
+- Subscription state surfaced in the UI via a `SubscriptionBadge` component and a `SubscriptionModal` for upgrade flows.
+- `/subscription/success` and `/subscription/cancel` return paths after checkout.
+- Feedback form accessible to all users (previously gated to authenticated users only).
+
+### Library and uploads
+
+- Drag-and-drop PDF upload with client-side validation and backend revalidation (`.pdf` only, max 100 MB).
+- Per-user file storage on disk under `storage/books/{user_id}/`, with signed URLs for secure access and a JSON/base64 delivery path that bypasses download managers like IDM.
+- Signed-URL-protected raw file endpoint (`GET /books/{book_id}/file`) and JSON data endpoint (`GET /books/{book_id}/data`).
+- Public thumbnail endpoint with a 24-hour `Cache-Control: public, max-age=86400` header.
+- Book delete cascades to file on disk and thumbnail.
+
+### Marketing site and SEO
+
+- Landing page with marketing copy, device compatibility notice, and open-source contribution callout.
+- Terms & Privacy page with test coverage.
+- SEO assets: `sitemap.xml`, `robots.txt`, `llms.txt`, `humans.txt`, `ai.txt`, and `.well-known/security.txt`, all served with the correct `Content-Type` headers via `vercel.json`.
+- Meta tags for search engine and AI-crawler discoverability.
+- Rebranded from "iReader" to "ReadEz" (favicon, copy, base URL).
+
+### Analytics
+
+- PostHog integration with session replays.
+- Tracked events include `app_loaded`, `page_navigated`, `pdf_loaded`, `reading_progress_saved`, and `zoom_changed`. See [docs/POSTHOG_EVENTS.md](docs/POSTHOG_EVENTS.md) for the full catalog.
+- Production PostHog config separated from development.
+
+### Infrastructure and deploy
+
+- Migrated from Supabase to a custom Python FastAPI backend. Supabase client removed from the frontend; all data access now goes through the ReadEz API.
+- Single-container deploy: multi-stage Dockerfile builds the Vite frontend and bundles it into the FastAPI image, which serves static assets and the API from one process.
+- Railway deployment with dynamic `PORT` binding, `/health` health check, and `ON_FAILURE` restart policy (max 3 retries).
+- Vercel deployment for the frontend-only path with SPA rewrites.
+- SPA routing handled via FastAPI middleware to avoid conflict with the Railway health check.
+- Automatic conversion of `postgresql://` to `postgresql+asyncpg://` for Railway-provisioned Postgres URLs.
+- Python installed in the Alpine frontend build stage to support `pdfjs-dist` native module compilation.
+
+### Fixes
+
+- Storage service bugs that caused 500 errors on upload.
+- Upload error handling: clearer diagnostics when writes fail, and the book record is now flushed before `ReadingProgress` is created so the foreign key is always valid.
+- SPA routing on refresh no longer 404s.
+- Relative URLs used in production instead of hardcoded `localhost`.
+- Removed unused `canvas` dependency.
+- Removed Vercel Analytics in favor of PostHog.
+
+### Testing and tooling
+
+- Vitest + Testing Library setup with `jsdom`.
+- Test coverage for `FeedbackForm`, `SubscriptionModal`, `Legal`, and `subscriptionHelpers`.
+- Postman collection (`docs/ReadEz.postman_collection.json`) for manual API testing.
+
+### For contributors
+
+- Python 3.11+ backend with `pypdf` for page count extraction.
+- SQLAlchemy async ORM with asyncpg driver.
+- Pydantic v2 settings via `pydantic-settings`.
+- Lightweight migration system under `backend/migrations/` (plain Python scripts, not Alembic).
+
+[Unreleased]: https://github.com/vaibhav-bansal/readez/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/vaibhav-bansal/readez/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+Project-level instructions for Claude Code and other AI coding assistants working in this repository. These rules are specific to ReadEz and layer on top of any global instructions the user has configured.
+
+## What ReadEz is
+
+ReadEz is a free, open-source web PDF reader. React 19 + Vite frontend, Python FastAPI + PostgreSQL backend. Google OAuth for auth, Dodo Payments for subscriptions, PostHog for analytics, Railway for deployment. See [ARCHITECTURE.md](ARCHITECTURE.md) for the full picture.
+
+The maintainer (`vaibhav-bansal`) is the sole developer. Code review is self-review. This means AI assistants should err on the side of explicit, readable code over clever abstractions — the reviewer has limited context budget.
+
+## Stack rules
+
+Match the existing stack. Do not introduce:
+
+- **A different frontend framework.** React + Vite + React Router + Tailwind + Zustand + TanStack Query is the stack. No Next.js, no Redux, no SWR.
+- **A different backend framework.** FastAPI + SQLAlchemy async + Pydantic v2 is the stack. No Flask, no Django, no sync SQLAlchemy.
+- **A different ORM pattern.** All database access is async. Every `def` that touches the database must be `async def`.
+- **A different CSS strategy.** Tailwind utility classes only. No CSS modules, no styled-components, no inline `style={{…}}` except for truly dynamic values (the reader's computed PDF dimensions are an accepted exception).
+- **A different auth provider.** Google OAuth with PKCE is it. Do not suggest Auth.js, Clerk, Supabase Auth, or similar — we already migrated away from Supabase on purpose.
+
+If you think the stack should change, say so in the PR description and wait for explicit approval. Do not quietly swap libraries.
+
+## Code style
+
+- **Frontend:** function components, hooks only. 2-space indent. Single quotes. No semicolons in files that already omit them. Match the surrounding file.
+- **Backend:** PEP 8, 4-space indent, type hints on public function signatures, `async def` for IO-bound code, `def` for pure helpers. Pydantic v2 models for request/response bodies.
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`). Keep the subject line under 72 characters.
+- **Imports:** absolute imports in the backend (`from app.models import User`), not relative. On the frontend, match the file you are editing — most use relative imports within `src/`.
+- **No emojis in code or docs** unless the user explicitly asks for them.
+- **No multi-line comments or multi-paragraph docstrings.** One short line if the *why* is non-obvious. Well-named identifiers beat explanatory comments.
+
+## Architectural constraints
+
+These are load-bearing. Do not change them without discussion:
+
+- **Base64 JSON PDF delivery is intentional.** `GET /books/{id}/data` returns `{ data: "base64…" }` instead of a raw PDF response. This bypasses download managers (IDM on Windows). If you "optimize" this to a file response, reading breaks for users with IDM installed. See [ARCHITECTURE.md](ARCHITECTURE.md).
+- **Signed URLs are checked in addition to session auth.** Do not remove the signature verification on `/books/{id}/data` or `/books/{id}/file`. Session auth alone is not enough.
+- **Reader is lazy-loaded.** `src/pages/Reader.jsx` is imported via `React.lazy()` in [src/App.jsx](src/App.jsx) because `pdfjs-dist` is heavy. Do not move the import to a static one. Do not import `pdfjs-dist` in other routes.
+- **SPA fallback is middleware, not a route.** The catch-all in `backend/app/main.py` uses `@app.middleware("http")` to avoid shadowing the `/health` check. Do not replace it with `@app.get("/{path:path}")`.
+- **Flush before create for foreign keys.** When creating a `Book` and a `ReadingProgress` together, flush the book first so the FK is valid. This was a real bug — do not reintroduce it.
+- **PostgreSQL URL rewriting at startup.** Railway provides `postgresql://…`; `database.py` rewrites it to `postgresql+asyncpg://…`. Keep the rewrite.
+- **`init_db()` creates tables but does not alter them.** Schema changes require a migration script under `backend/migrations/`. Do not rely on model edits propagating via `create_all`.
+- **Dodo webhook verification uses the Standard Webhooks spec.** HMAC-SHA256 of `{webhook_id}.{webhook_timestamp}.{body}` with a base64-decoded secret. The `whsec_` prefix is stripped. Do not "simplify" this.
+
+## Things to never do
+
+- **Never commit secrets.** `.env`, `.env.production`, `backend/.env`. If you see one staged, stop and warn the user.
+- **Never disable auth, CORS, or webhook verification** to "make it work locally". If something is broken, fix the root cause.
+- **Never bypass `--no-verify` on commits** unless the user explicitly tells you to.
+- **Never force-push to `main`.**
+- **Never delete user data without an explicit user instruction.** `storage/`, database rows, uploaded books. These represent real user files.
+- **Never add a new npm or pip dependency** without checking the existing `package.json` / `requirements.txt` first. Prefer the built-in or existing solution.
+- **Never create `.md` files** unless explicitly requested. The project already has a defined set of documentation files. Do not scatter new READMEs or ad-hoc notes into the repo.
+- **Never refactor unrelated code** in a bug-fix PR. One concern per commit.
+
+## Testing
+
+- Frontend tests run with `npm test` (Vitest + Testing Library + jsdom).
+- There is no backend test suite yet. If you add one, put it under `backend/tests/` and use `pytest` + `pytest-asyncio`.
+- Before claiming work is complete:
+  1. Run `npm test` if you touched the frontend.
+  2. Manually verify the change in the browser at `http://localhost:5173`. Type-checking and tests catch code correctness; only the browser catches feature correctness.
+  3. If the change affects the reader, the library, upload, or auth, walk through the golden path end-to-end.
+
+Do not claim "should work" without evidence. Say what you verified.
+
+## Verification-before-completion
+
+When reporting task completion:
+
+- State what you ran (the exact command) and what you saw (the exact output summary).
+- State what you manually tested in the browser, including which routes and which interactions.
+- If you could not test the UI (no dev server, no browser, CI context), say so explicitly rather than claiming success.
+
+## Documentation rules
+
+- **README.md** — product-facing. Polish with care. Voice is first-person when talking about *why* ReadEz exists, neutral when documenting *how* to use it.
+- **CONTRIBUTING.md** — contributor-facing. Neutral, practical.
+- **ARCHITECTURE.md** — describes the current state. Update when you change request flow, add a service, or move code between layers.
+- **CHANGELOG.md** — Keep a Changelog format. Update the `Unreleased` section when your change affects user-visible behavior. Never overwrite existing entries.
+- **SECURITY.md** — update if you change how auth, sessions, signed URLs, webhook verification, or secrets handling works.
+- **backend/README.md** — update if you change backend setup, entry points, or env variables.
+- **docs/** — historical design docs and internal planning. Treat as reference, not source of truth. Do not edit unless explicitly asked.
+
+When adding a user-visible feature, the PR should touch **at least** `CHANGELOG.md` (Unreleased section). When adding or changing an env variable, the PR should touch **both** `.env.example` files *and* the environment variable table in `CONTRIBUTING.md`.
+
+## User's global preferences (from their CLAUDE.md)
+
+The maintainer is not an engineer. Keep explanations in plain language, avoid jargon without explanation, and when a technical concept is necessary, explain it briefly with an analogy.
+
+Other standing preferences:
+
+- **Macro over micro.** Summaries, PR descriptions, and status updates should focus on outcomes ("reading progress now survives across devices"), not artifacts ("modified 4 files, added 127 lines").
+- **Never assume, always ask.** Ambiguous requests get clarifying questions, not guesses. Better slow and correct than fast and wrong.
+- **Use what exists.** Before writing custom code, search for a framework built-in, a popular open-source package, or an existing template. Custom code is a last resort. If you do write custom code, explain what you searched for and why the available options did not fit.
+- **Code reviews.** When asked to review, rank issues by user impact, describe each with a user-facing example, list approaches, and give a recommendation with reasoning. For frontend work, also take screenshots.
+
+## When you are uncertain
+
+Stop and ask. The reviewer prefers a short clarifying question over an hour of undoing an assumption. Red flags that should trigger a question:
+
+- You are about to introduce a new dependency.
+- You are about to change a file in `backend/app/routes/auth.py`, `webhooks.py`, or `storage.py`.
+- You are about to modify the Dockerfile, `railway.toml`, or `vercel.json`.
+- You are about to touch anything in `backend/migrations/`.
+- You are about to edit `.env.example` or add a new env variable.
+- The task description could reasonably be interpreted more than one way.
+
+For everything else: read the relevant file, make the smallest change that works, and explain what you did.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,182 @@
+# Contributing to ReadEz
+
+Thanks for your interest in ReadEz. This document covers how to set up a development environment, the expected code style, and the pull request process.
+
+If you just want to report a bug or request a feature, open an issue on [GitHub Issues](https://github.com/vaibhav-bansal/readez/issues). For security vulnerabilities, see [SECURITY.md](SECURITY.md) — do not file those as public issues.
+
+## Prerequisites
+
+You will need:
+
+- **Node.js 20 or newer** (the Dockerfile uses `node:20-alpine`)
+- **Python 3.11 or newer** (the Dockerfile uses `python:3.11-slim`)
+- **PostgreSQL 14 or newer**, accessible locally or via a hosted provider
+- **Google OAuth credentials** — a Cloud Console project with an OAuth 2.0 client ID and a redirect URI of `http://localhost:8000/auth/google/callback` for local dev
+- **Git**
+
+Optional:
+
+- A [PostHog](https://posthog.com) project for analytics (development works fine without it)
+- [Dodo Payments](https://dodopayments.com) test credentials if you plan to touch subscription code
+
+## First-time setup
+
+### 1. Clone and install frontend dependencies
+
+```bash
+git clone https://github.com/vaibhav-bansal/readez.git
+cd readez
+npm install
+```
+
+The `postinstall` script copies the PDF.js worker into `public/`. If you see missing-worker errors later, run `npm run postinstall` manually.
+
+### 2. Install backend dependencies
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate          # macOS / Linux
+.venv\Scripts\activate              # Windows (PowerShell or cmd)
+pip install -r requirements.txt
+```
+
+### 3. Configure environment variables
+
+Copy both example env files and fill them in:
+
+```bash
+cp .env.example .env                # frontend
+cp backend/.env.example backend/.env # backend
+```
+
+Minimum required values for local development:
+
+| Variable | Where | Notes |
+|---|---|---|
+| `DATABASE_URL` | `backend/.env` | Must use the `postgresql+asyncpg://` scheme |
+| `GOOGLE_CLIENT_ID` | `backend/.env` | From Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | `backend/.env` | From Google Cloud Console |
+| `SESSION_SECRET_KEY` | `backend/.env` | Any random string, minimum 32 characters |
+| `FRONTEND_URL` | `backend/.env` | `http://localhost:5173` for local dev |
+| `BACKEND_URL` | `backend/.env` | `http://localhost:8000` for local dev |
+
+All Dodo and PostHog variables can be left blank locally. The app degrades gracefully when they are missing.
+
+### 4. Create the database
+
+```bash
+createdb readez
+```
+
+The backend runs `init_db()` on startup, which creates tables from SQLAlchemy models if they do not exist. There is no separate migrate step for the initial schema.
+
+### 5. Run the app
+
+Two terminals:
+
+```bash
+# Terminal 1 — backend
+cd backend
+source .venv/bin/activate
+uvicorn app.main:app --reload --port 8000
+```
+
+```bash
+# Terminal 2 — frontend
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173). Sign in with Google, upload a PDF, and confirm the reader works.
+
+## Project layout
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full breakdown. A quick map:
+
+```
+readez/
+  src/                  React frontend (Vite)
+    components/         Reusable UI
+    pages/              Route-level pages (Landing, Library, Reader, Legal, Feedback, Subscription*)
+    hooks/              Custom React hooks (useSubscription, etc.)
+    lib/                API client, PDF worker config, analytics, Dodo helpers
+    store/              Zustand stores
+    test/               Vitest setup
+  backend/
+    app/
+      main.py           FastAPI entry point, router registration, SPA middleware
+      config.py         Pydantic settings
+      database.py       Async SQLAlchemy engine and session factory
+      models/           User, Book, ReadingProgress, Session, Subscription, Payment, Feedback
+      routes/           auth, books, progress, subscription, payments, webhooks, feedback
+      services/         storage (file I/O, signed URLs)
+      middleware/       Auth dependency
+    migrations/         Lightweight Python migration scripts
+  docs/                 Long-form design docs, Postman collection, internal planning
+  scripts/              Build-time helpers (PDF.js worker copy)
+  Dockerfile            Multi-stage build: Vite frontend → FastAPI serves both
+  vercel.json           Frontend-only Vercel config
+  railway.toml          Single-container Railway config
+```
+
+## Running tests
+
+```bash
+npm test              # run vitest once
+npm run test:ui       # open the Vitest UI
+```
+
+Current test coverage is intentionally narrow — legal pages, subscription helpers, subscription modal, feedback form. New code in critical paths (auth, uploads, payments) should come with tests where practical.
+
+There is no backend test suite yet. If you add one, put it under `backend/tests/` and wire it up with `pytest`.
+
+## Code style
+
+No auto-formatter is enforced yet. Match the surrounding code:
+
+- **Frontend:** modern React (hooks, function components), 2-space indent, single quotes, no semicolons in new files if the file already omits them.
+- **Backend:** PEP 8, 4-space indent, type hints on function signatures, `async def` for anything touching the database or network.
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`) as used in the existing history.
+
+Keep functions small. Prefer explicit over clever. If you reach for an abstraction, make sure it pays for itself in at least two call sites.
+
+## Pull request process
+
+1. Fork the repository and create a branch off `main`:
+
+   ```bash
+   git checkout -b feat/your-feature
+   ```
+
+2. Make focused commits. A PR should do one thing.
+
+3. Run the frontend tests before pushing:
+
+   ```bash
+   npm test
+   ```
+
+4. If your change affects behavior a user can see, update the `Unreleased` section of [CHANGELOG.md](CHANGELOG.md).
+
+5. Push and open a PR against `main`. In the description, explain:
+   - What changed and why
+   - How to manually verify it (routes hit, buttons clicked, env vars set)
+   - Any follow-up work you deferred
+
+6. The maintainer (currently just me) will review. Expect questions. Small PRs get merged faster than big ones.
+
+## Things that will get a PR rejected
+
+- **Committing secrets.** `.env`, `.env.production`, API keys, service account JSON. If you commit one by accident, rotate it immediately, then force-push a corrected branch.
+- **Committing `node_modules/`, `dist/`, `.venv/`, or `storage/`.** These are gitignored for a reason.
+- **Breaking auth or payment flows without tests.** The impact is too high.
+- **Large unrelated refactors bundled with a feature.** Split them.
+- **New dependencies without justification.** If a two-line helper will do, write the helper.
+
+## Working with Claude Code / AI assistants
+
+This repo has a project-level [CLAUDE.md](CLAUDE.md) that codifies the conventions AI assistants should follow when making changes here. If you are using Claude Code, Cursor, or similar tools, point them at that file. If you add a new convention that an AI should know about, update `CLAUDE.md` in the same PR.
+
+## Questions
+
+Open a [Discussion](https://github.com/vaibhav-bansal/readez/discussions) or an issue. For anything security-related, follow [SECURITY.md](SECURITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,53 @@
 # ReadEz
 
-A free, open-source web-based PDF reader with infinite scroll, progress tracking, and cross-device sync.
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-20%2B-brightgreen)](https://nodejs.org)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://python.org)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)](CONTRIBUTING.md)
+
+A free, open-source web-based ebook reader. Upload your PDFs, read them in a clean infinite-scroll interface, and pick up exactly where you left off on any device.
+
+## Why I built this
+
+I read a lot of PDFs. Textbooks, papers, long-form reports, the occasional leaked startup memo. Every existing option wanted me to either live inside one company's ecosystem, pay a subscription for features I already had, or accept a reading experience built for office work from 2003.
+
+ReadEz is the reader I wanted: fast, clean, keyboard-friendly, cross-device, and mine. Upload a PDF, it remembers where you stopped, and the next time you open the same book on your phone it is waiting on the right page. No lock-in. No ads. The code is open — if something is broken, you can fix it.
 
 ## Features
 
-- Upload and manage PDF books with drag-and-drop
-- Infinite scroll reading experience
-- Automatic reading progress tracking
-- Cross-device sync
-- Google Sign-in authentication
-- Responsive design (mobile, tablet, desktop)
-- Auto-generated book cover thumbnails
+- **Drag-and-drop PDF upload** with per-user private storage
+- **Infinite-scroll reader** with keyboard shortcuts, touch gestures, and dynamic zoom
+- **Cross-device reading progress sync** — page, scroll position, and zoom level
+- **Google Sign-In** with server-side sessions
+- **Responsive** across mobile, tablet, and desktop
+- **Auto-generated book cover thumbnails** from the first PDF page
+- **Optional Pro / Plus subscriptions** via Dodo Payments
+- **Privacy-respecting analytics** with PostHog (opt-in, self-hostable)
 
 ## Tech Stack
 
 **Frontend:** React 19, Vite, Tailwind CSS, Zustand, TanStack Query, react-pdf
 
-**Backend:** Python, FastAPI, SQLAlchemy, PostgreSQL (asyncpg)
+**Backend:** Python 3.11, FastAPI, SQLAlchemy (async), PostgreSQL (asyncpg), pypdf
 
-**Auth:** Google OAuth
+**Auth:** Google OAuth 2.0 with PKCE
+
+**Payments:** Dodo Payments (optional)
 
 **Analytics:** PostHog (optional)
 
-## Getting Started
+**Deploy:** Railway (single container) or Vercel + separate backend
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for how all of this fits together.
+
+## Quick start
 
 ### Prerequisites
 
 - Node.js 20+
 - Python 3.11+
-- PostgreSQL database
-- Google OAuth credentials
+- PostgreSQL
+- Google OAuth credentials ([Cloud Console](https://console.cloud.google.com))
 
 ### 1. Clone and install
 
@@ -44,108 +62,87 @@ npm install
 ```bash
 cd backend
 python -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+source .venv/bin/activate          # macOS / Linux
+.venv\Scripts\activate              # Windows
 pip install -r requirements.txt
-```
-
-Copy the example env file and fill in your values:
-
-```bash
 cp .env.example .env
 ```
 
-Key environment variables:
-
-| Variable | Description |
-|---|---|
-| `DATABASE_URL` | PostgreSQL connection string |
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
-| `SESSION_SECRET_KEY` | Random secret key (min 32 chars) |
-| `FRONTEND_URL` | Frontend URL (default: `http://localhost:5173`) |
-| `BACKEND_URL` | Backend URL (default: `http://localhost:8000`) |
+Fill in `backend/.env` with your Postgres URL, Google OAuth credentials, and a random `SESSION_SECRET_KEY` (minimum 32 characters). Full details in [CONTRIBUTING.md](CONTRIBUTING.md#3-configure-environment-variables).
 
 ### 3. Set up the frontend
 
-Create a `.env` file in the project root:
-
-```env
-VITE_POSTHOG_KEY=your_posthog_project_api_key       # optional
-VITE_POSTHOG_HOST=https://app.posthog.com            # optional
+```bash
+cd ..       # back to repo root
+cp .env.example .env
 ```
 
-### 4. Run in development
+PostHog and Dodo values are optional for local development.
 
-Start the backend:
+### 4. Run it
 
 ```bash
+# Terminal 1
 cd backend
 uvicorn app.main:app --reload --port 8000
 ```
 
-Start the frontend (in a separate terminal):
-
 ```bash
+# Terminal 2
 npm run dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) in your browser.
+Open [http://localhost:5173](http://localhost:5173), sign in with Google, and upload a PDF.
 
-## Project Structure
+## Documentation
 
-```
-readez/
-  src/                    # React frontend
-    components/           # Reusable UI components
-    pages/                # Route pages (Library, Reader, Landing, etc.)
-    hooks/                # Custom React hooks
-    lib/                  # Utilities (API client, PDF worker, analytics)
-    store/                # Zustand state management
-  backend/                # FastAPI backend
-    app/
-      models/             # SQLAlchemy models
-      routes/             # API route handlers
-      services/           # Business logic (storage, etc.)
-      middleware/         # Auth middleware
-      config.py           # App configuration
-      database.py         # Database setup
-      main.py             # FastAPI app entry point
-```
+| Doc | What's in it |
+|---|---|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | How the frontend, backend, and data model fit together |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup, code style, PR process |
+| [SECURITY.md](SECURITY.md) | How to report vulnerabilities and the current security posture |
+| [CHANGELOG.md](CHANGELOG.md) | What shipped in each release |
+| [CLAUDE.md](CLAUDE.md) | Conventions for AI coding assistants working in this repo |
+| [backend/README.md](backend/README.md) | Backend-specific setup and structure |
+| [docs/POSTHOG_EVENTS.md](docs/POSTHOG_EVENTS.md) | Catalog of analytics events |
+| [docs/RAILWAY_DEPLOYMENT.md](docs/RAILWAY_DEPLOYMENT.md) | Railway deployment walkthrough |
+| [docs/QUICKSTART.md](docs/QUICKSTART.md) | Condensed setup guide |
+| [docs/ReadEz.postman_collection.json](docs/ReadEz.postman_collection.json) | Postman collection for the API |
 
 ## Deployment
 
-### Docker
+### Railway (recommended)
 
-Build and run with Docker:
+Single-container deploy. The [Dockerfile](Dockerfile) builds the Vite frontend, bundles it into the FastAPI image, and serves both from one process.
+
+1. Connect your GitHub repository to Railway
+2. Set the environment variables listed in [backend/.env.example](backend/.env.example)
+3. Railway auto-detects the Dockerfile and deploys. Healthcheck is `/health`.
+
+See [docs/RAILWAY_DEPLOYMENT.md](docs/RAILWAY_DEPLOYMENT.md) for a step-by-step walkthrough.
+
+### Vercel (frontend only)
+
+The [vercel.json](vercel.json) file configures a frontend-only deploy. You will need to run the backend separately and configure CORS via `FRONTEND_URL` on the backend.
+
+### Docker (self-hosted)
 
 ```bash
 docker build -t readez .
 docker run -p 8000:8000 \
-  -e DATABASE_URL=your_database_url \
+  -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/readez \
   -e GOOGLE_CLIENT_ID=your_client_id \
   -e GOOGLE_CLIENT_SECRET=your_client_secret \
-  -e SESSION_SECRET_KEY=your_secret_key \
+  -e SESSION_SECRET_KEY=your_32_char_secret \
   -e FRONTEND_URL=https://your-domain.com \
   -e BACKEND_URL=https://your-domain.com \
   readez
 ```
 
-### Railway
-
-1. Connect your GitHub repository to Railway
-2. Set the required environment variables
-3. Deploy
-
 ## Contributing
 
-Contributions are welcome! Please feel free to open an issue or submit a pull request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/your-feature`)
-3. Commit your changes (`git commit -m 'feat: add your feature'`)
-4. Push to the branch (`git push origin feature/your-feature`)
-5. Open a Pull Request
+PRs are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) first — it covers setup, code style, and the PR process. For security issues, follow [SECURITY.md](SECURITY.md) instead of filing a public issue.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,121 @@
+# Security Policy
+
+ReadEz handles user authentication, uploaded files, and payment processing. Security reports are taken seriously and prioritized above feature work.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security problems.** Please use one of these channels instead:
+
+1. **GitHub Private Vulnerability Reporting** (preferred)
+   Go to the [Security tab](https://github.com/vaibhav-bansal/readez/security) of the repository and click "Report a vulnerability". This creates a private advisory that only the maintainer can see.
+
+2. **Email**
+   If private reporting is not available, contact the maintainer directly through the email address on their [GitHub profile](https://github.com/vaibhav-bansal).
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (or a proof-of-concept if you have one)
+- The affected version, commit, or deployment URL
+- Any mitigating factors you are aware of
+- Whether you want to be credited publicly once the fix lands
+
+## What to expect
+
+- **Acknowledgement:** within 72 hours of your report.
+- **Triage:** within 7 days, with an initial assessment of severity and scope.
+- **Fix and disclosure:** timeline depends on severity. Critical issues get patched as fast as possible; lower-severity issues get scheduled.
+- **Credit:** if you want it, you will be credited in the release notes and the security advisory.
+
+Please do not publicly disclose the issue until a fix has been released and you have given users a reasonable window to update.
+
+## Scope
+
+In scope:
+
+- The ReadEz web application (`src/`) and backend API (`backend/app/`)
+- Authentication and session handling
+- File upload, storage, and signed-URL access control
+- Dodo Payments webhook handling
+- The official deployment at the URL listed in README.md
+- The `Dockerfile` and deployment configurations (`railway.toml`, `vercel.json`)
+
+Out of scope:
+
+- Issues in third-party dependencies (report those to the upstream project; we will track and upgrade)
+- Denial-of-service attacks that require unrealistic traffic volumes
+- Social engineering against maintainers or users
+- Physical attacks
+- Missing security headers on pages that do not handle sensitive data, where no practical attack exists
+- Self-hosted installations that have modified the default security configuration
+- Attacks requiring compromised developer machines or malicious dependencies at install time
+
+## Known security posture
+
+This section is meant to help security researchers understand what is already in place, so you can focus on real gaps rather than re-reporting intentional choices.
+
+### Authentication
+
+- **Google OAuth 2.0 with PKCE (S256).** Authorization codes cannot be replayed without the verifier.
+- **State parameter** is generated per request and stored in a short-lived (10 min) HttpOnly cookie, validated on callback to prevent CSRF on the OAuth flow.
+- **`id_token` handling.** The token is decoded as a JWT without signature verification because it is received directly from Google over HTTPS in a backchannel (token endpoint) request. Signature verification is not required in this flow per RFC 8252. If we ever move to a flow where the `id_token` comes through an untrusted path, verification becomes mandatory.
+
+### Sessions
+
+- **Cookies:** `HttpOnly`, `Secure` (auto-detected via `X-Forwarded-Proto` for Railway), `SameSite=Lax`, default 30-day expiry.
+- **Server-side session rows** in Postgres allow revocation. Logout deletes the row; compromised sessions can be forcibly ended.
+- **Session metadata** (`user_agent`, `ip_address`) is stored for audit purposes.
+
+### File access
+
+- **Signed URLs.** Book file and data endpoints require a signed URL with an expiry timestamp. The signature is HMAC-SHA256 over `{book_id}|{user_id}|{expires_at}` using `SESSION_SECRET_KEY`. Links are short-lived.
+- **Per-user directories.** Files are stored under `storage/books/{user_id}/`, and ownership is checked on every access regardless of the signed URL. Signed URLs alone are not sufficient.
+- **File name sanitization.** Uploaded files are renamed to `{unix_ms}.pdf` on disk. The original filename never hits the filesystem.
+- **Upload validation.** `.pdf` extension and max 100 MB size enforced on the backend (frontend validation is only a UX convenience).
+
+### Payments and webhooks
+
+- **Webhook signature verification** follows the [Standard Webhooks](https://www.standardwebhooks.com) spec: HMAC-SHA256 over `{webhook_id}.{webhook_timestamp}.{body}` with a base64-decoded secret, constant-time comparison.
+- **Separate secrets** for subscription, payment, and refund event types, and separate sets for test vs live environments.
+- **Webhook payloads** are stored in the `Payment.webhook_data` column for audit and dispute handling.
+- **If the webhook secret is not configured, verification is skipped.** This is a deliberate development convenience. In production, **always** configure webhook secrets. Missing secrets in production is a configuration bug and should be treated as a security issue.
+
+### Input validation
+
+- **Pydantic v2 models** validate every request body. FastAPI rejects malformed payloads before they reach route handlers.
+- **SQLAlchemy ORM** parameterizes all queries. There is no raw SQL in the codebase.
+- **CORS** is scoped to `FRONTEND_URL` with credentials allowed. No wildcard origins.
+
+### Secrets
+
+- **No secrets in the repository.** `.env`, `.env.production`, and `backend/.env` are gitignored. Only `.env.example` files (with placeholder values) are tracked.
+- **`SESSION_SECRET_KEY`** is required. A minimum of 32 characters is expected but not enforced — please use a cryptographically random value in production.
+- **Google, Dodo, and PostHog credentials** are loaded from the environment at startup via `pydantic-settings`.
+
+## Things we know are weaker than they should be
+
+Transparent about current gaps, so researchers know where to look and users know what to expect:
+
+- **No rate limiting.** Login, upload, and webhook endpoints are not rate-limited. A determined attacker can brute-force login flows or upload spam. On the roadmap.
+- **No virus scanning on uploads.** Uploaded PDFs are trusted to be well-formed. Malicious PDFs with exploits targeting older PDF.js versions are possible. Keeping `pdfjs-dist` up to date is currently the only mitigation.
+- **`init_db()` auto-creates tables** from models on startup. Schema drift between models and production is possible. Explicit migrations (see [backend/migrations/](backend/migrations/)) partially mitigate this.
+- **`SESSION_SECRET_KEY` rotation requires re-login for all users.** There is no key rotation window.
+- **Session cookies do not have a fingerprint.** A stolen cookie works until the session expires or is revoked. Binding sessions to user agent or IP is a tradeoff (usability vs security) we have not made yet.
+- **Local disk storage** means a single-host deploy. Multi-region or multi-replica setups would need object storage. Not a vulnerability per se, but an operational constraint worth knowing.
+
+If you find something not listed here, please report it.
+
+## Hardening checklist for self-hosters
+
+If you are running your own instance of ReadEz, please:
+
+- Set `SESSION_SECRET_KEY` to a long random value (`python -c "import secrets; print(secrets.token_urlsafe(48))"`).
+- Set `ENVIRONMENT=production`.
+- Configure all six Dodo webhook secrets if you are using subscriptions.
+- Terminate TLS at your load balancer and pass `X-Forwarded-Proto: https` to the container.
+- Restrict database network access to the application host.
+- Run database backups.
+- Keep dependencies up to date — `npm audit` and `pip list --outdated` are your friends.
+- Subscribe to this repository's releases so you get notified when security-relevant fixes land.
+
+Thank you for helping keep ReadEz and its users safe.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,236 @@
+# ReadEz Backend
+
+FastAPI service that powers the ReadEz reader. Handles authentication, PDF storage, reading progress sync, subscriptions, and webhooks from Dodo Payments.
+
+For the full project overview, see [../README.md](../README.md). For the architecture, see [../ARCHITECTURE.md](../ARCHITECTURE.md).
+
+## Stack
+
+- **Python 3.11+**
+- **FastAPI** (async)
+- **SQLAlchemy 2.x** with the `asyncpg` driver for PostgreSQL
+- **Pydantic v2** for request/response schemas and settings
+- **httpx** for outbound HTTP (Google OAuth, Dodo API)
+- **pypdf** for PDF page count extraction
+- **aiofiles** for async file I/O
+
+Full dependency list in [requirements.txt](requirements.txt).
+
+## Directory layout
+
+```
+backend/
+  app/
+    main.py              FastAPI app, router registration, SPA middleware, /health
+    config.py            Pydantic settings loaded from environment
+    database.py          Async engine, session factory, init_db()
+    models/
+      __init__.py        Re-exports all models and enums
+      user.py            User
+      session.py         Session (server-side login sessions)
+      book.py            Book, ReadingProgress
+      subscription.py    Subscription, Payment, SubscriptionUsage, SubscriptionTier, SubscriptionStatus
+      feedback.py        Feedback
+    routes/
+      __init__.py        Router aggregation
+      auth.py            /auth/* — Google OAuth, sessions, /me, /status, /logout
+      books.py           /books/* — upload, list, get, delete, signed URLs, data delivery, thumbnails, page count backfill
+      progress.py        /progress/* — reading progress read/write
+      subscription.py    /subscription/* — active subscription, usage, checkout
+      payments.py        /payments/* — payment history
+      webhooks.py        /webhooks/* — Dodo subscription, payment, refund event handlers
+      feedback.py        /feedback/* — user feedback submissions
+    services/
+      storage.py         StorageService — disk I/O, signed URLs, thumbnails
+    middleware/
+      auth.py            get_current_user dependency, session cookie handling
+  migrations/            Lightweight Python migration scripts (not Alembic)
+  storage/               Runtime storage for books and thumbnails (gitignored)
+  requirements.txt
+  .env.example
+```
+
+## Setup
+
+### 1. Create a virtual environment
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate          # macOS / Linux
+.venv\Scripts\activate              # Windows
+```
+
+### 2. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and fill in:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DATABASE_URL` | Yes | Must use the `postgresql+asyncpg://` scheme |
+| `GOOGLE_CLIENT_ID` | Yes | From Google Cloud Console OAuth credentials |
+| `GOOGLE_CLIENT_SECRET` | Yes | From Google Cloud Console OAuth credentials |
+| `SESSION_SECRET_KEY` | Yes | Random string, minimum 32 characters. Used for session signing and signed URLs. |
+| `SESSION_EXPIRE_DAYS` | No | Default `30` |
+| `FRONTEND_URL` | Yes | Used for CORS and OAuth redirect building. `http://localhost:5173` for local dev. |
+| `BACKEND_URL` | Yes | Used to build OAuth callback URLs. `http://localhost:8000` for local dev. |
+| `STORAGE_PATH` | No | Default `./storage`. Where uploaded PDFs and thumbnails live. |
+| `ENVIRONMENT` | No | `development` (default) or `production`. Controls which Dodo credentials are active. |
+| `DEBUG` | No | Default `false` |
+
+**Dodo Payments** variables are optional and only required if you are testing subscriptions. Six secrets per environment (test / live) — see [.env.example](.env.example).
+
+**A note on `DATABASE_URL`:** Railway and some other hosts provide `postgresql://…`. The app rewrites that to `postgresql+asyncpg://…` at startup, so either form works at deploy time. For local dev, write it with the `+asyncpg` scheme explicitly.
+
+### 4. Set up PostgreSQL
+
+```bash
+createdb readez
+```
+
+Tables are created automatically by `init_db()` on first startup via `Base.metadata.create_all()`. There is no separate "run migrations" step for the initial schema — migrations live in `migrations/` as standalone Python scripts for schema changes after the initial deploy.
+
+### 5. Run the server
+
+```bash
+uvicorn app.main:app --reload --port 8000
+```
+
+The API is now at `http://localhost:8000`. Open `http://localhost:8000/docs` for FastAPI's auto-generated OpenAPI UI.
+
+## Key endpoints
+
+A quick reference. For the full surface, run the server and visit `/docs`, or import [../docs/ReadEz.postman_collection.json](../docs/ReadEz.postman_collection.json) into Postman.
+
+### Health
+
+- `GET /health` — returns `{ status: "healthy", environment }`. Used by Railway.
+
+### Auth
+
+- `GET /auth/google/login` — returns `{ authorization_url }`, sets `oauth_state` cookie (10 min).
+- `GET /auth/google/callback?code=…&state=…` — OAuth callback. Validates state, exchanges code with PKCE, upserts the user, sets the session cookie, returns an HTML page that posts a message to the opener window.
+- `GET /auth/me` — current authenticated user.
+- `GET /auth/status` — `{ authenticated: bool, user?: {...} }`.
+- `POST /auth/logout` — deletes the session row and clears the cookie.
+
+### Books
+
+- `GET /books` — list current user's books.
+- `POST /books` — multipart upload. Extracts `total_pages`, writes to disk, creates `Book` + `ReadingProgress`.
+- `GET /books/{id}` — book metadata.
+- `DELETE /books/{id}` — deletes row and cascades to file and thumbnail.
+- `GET /books/{id}/signed-url` — returns `{ url, expires_at }` for secure file access.
+- `GET /books/{id}/data?signature=…&expires=…` — base64-encoded JSON payload (bypasses download managers).
+- `GET /books/{id}/file?signature=…&expires=…` — raw PDF response with `inline` disposition.
+- `POST /books/{id}/thumbnail` — upload a custom thumbnail.
+- `GET /books/{id}/thumbnail` — public thumbnail endpoint, 24-hour cache.
+- `PATCH /books/{id}/page-count` — lazy backfill of `total_pages` from the frontend.
+- `POST /books/backfill/page-counts` — bulk backfill for the user's books.
+
+### Progress
+
+- `GET /progress/{book_id}` — current reading progress.
+- `PATCH /progress/{book_id}` — update `current_page`, `scroll_position`, `zoom_level`. Frontend calls this with a 500 ms debounce.
+
+### Subscription / Payments
+
+- `GET /subscription` — active subscription, usage, recent payments.
+- `POST /subscription/checkout` — create a Dodo checkout session (details depend on tier).
+- `GET /payments` — payment history.
+
+### Webhooks (Dodo Payments)
+
+- `POST /webhooks/subscription` — subscription lifecycle events.
+- `POST /webhooks/payment` — payment succeeded / failed.
+- `POST /webhooks/refund` — refunds.
+
+All three verify the signature using HMAC-SHA256 over `{webhook_id}.{webhook_timestamp}.{body}` with a base64-decoded secret, per the [Standard Webhooks](https://www.standardwebhooks.com) spec.
+
+### Feedback
+
+- `POST /feedback` — submit feedback. Works anonymously or authenticated.
+
+## Data model
+
+The full model is in [../ARCHITECTURE.md](../ARCHITECTURE.md#data-model). Quick summary:
+
+- **User** — Google identity, profile, timestamps.
+- **Session** — server-side login sessions with user agent and IP.
+- **Book** — uploaded PDF metadata (file path, size, page count, thumbnail).
+- **ReadingProgress** — one per (user, book) with current page, scroll, zoom.
+- **Subscription** — one per user, linked to Dodo.
+- **Payment** — payment and refund history keyed by Dodo IDs.
+- **SubscriptionUsage** — per-feature usage counters with monthly resets.
+- **Feedback** — user feedback, optionally anonymous.
+
+## Migrations
+
+Migrations are lightweight Python scripts under `migrations/`. Example: [`add_payment_external_ids.py`](migrations/add_payment_external_ids.py).
+
+To run a migration:
+
+```bash
+cd backend
+source .venv/bin/activate
+python -m migrations.add_payment_external_ids
+```
+
+Write new migration scripts following the same pattern: import the async engine, execute the DDL, commit, print a confirmation. If the schema starts changing frequently, we will migrate to Alembic.
+
+**Do not rely on `init_db()` for anything beyond initial table creation.** It calls `Base.metadata.create_all()`, which does not alter existing tables.
+
+## Storage
+
+`StorageService` in [app/services/storage.py](app/services/storage.py) wraps all file I/O. Files are stored under:
+
+```
+{STORAGE_PATH}/books/{user_id}/{unix_ms}.pdf
+{STORAGE_PATH}/thumbnails/{user_id}/{unix_ms}.jpg
+```
+
+Using a Unix-millisecond timestamp as the filename prevents collisions and does not leak original filenames.
+
+**Signed URLs** are HMAC-SHA256 tokens over `{book_id}|{user_id}|{expires_at}` with `SESSION_SECRET_KEY` as the key. Short-lived by design — long enough for a page load, short enough to prevent link-sharing.
+
+**Scaling note:** local disk works fine for a single-instance deploy. Multi-replica setups need to move to object storage (S3, R2, etc.). The interface is already isolated in `StorageService`, so the swap is contained.
+
+## Testing
+
+There is no backend test suite yet. If you are adding one:
+
+- Put tests under `backend/tests/`
+- Use `pytest` + `pytest-asyncio`
+- Use a separate test database (respect `DATABASE_URL` via pytest fixtures)
+- Start with the high-value paths: auth callback, book upload, progress updates, webhook verification
+
+Frontend tests live in the root (`src/**/*.test.{js,jsx}`) and run with `npm test` from the repo root.
+
+## Common issues
+
+**`sqlalchemy.exc.InvalidRequestError: Mapper … already has a property …`** — happens when a model file is imported twice with different paths. Fix: use absolute imports (`from app.models import User`), not relative.
+
+**`asyncpg.exceptions.InvalidPasswordError`** — your `DATABASE_URL` password is wrong or URL-escaped incorrectly. Special characters must be percent-encoded.
+
+**`Setting up fake worker` in the frontend reader** — not a backend issue. Run `npm run postinstall` from the repo root to copy the PDF.js worker.
+
+**Railway healthcheck failing** — confirm `uvicorn` is binding to `$PORT`, not a hardcoded port. The Dockerfile handles this; if you change the `CMD`, keep the `$PORT` variable.
+
+**Google OAuth redirect mismatch** — the callback URL registered in Google Cloud Console must exactly match `{BACKEND_URL}/auth/google/callback`. Trailing slashes matter.
+
+## See also
+
+- [../ARCHITECTURE.md](../ARCHITECTURE.md) — full system architecture
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — contributor guide
+- [../SECURITY.md](../SECURITY.md) — security policy
+- [../CLAUDE.md](../CLAUDE.md) — AI assistant conventions


### PR DESCRIPTION
## Summary

Backfills the full open-source documentation suite that the repo was missing. Seven files, one commit. Macro outcome: ReadEz now looks and reads like a professional, contributor-ready project. A new contributor (or a security researcher, or future-me) can land on this repo and find everything they need without asking questions.

- **README.md** — polished with badges, a personal "why I built this" intro, and a documentation hub linking all the new docs
- **CHANGELOG.md** — Keep a Changelog format; one 1.0.0 entry backfilled from git history (Dec 2025 → Apr 2026), grouped by theme: reading experience, auth, subscriptions, library, marketing/SEO, analytics, infrastructure, fixes, testing
- **CONTRIBUTING.md** — prerequisites, both-halves setup (frontend + backend), env var table, project layout, tests, code style, PR process, rejection list
- **ARCHITECTURE.md** — ASCII system diagram, routes table, state layers, reader deep-dive (signed URLs, base64 delivery, progress tracking), backend routers, data model with real field names, request flows, deploy shapes, "things worth knowing"
- **SECURITY.md** — reporting channels, scope, current posture (auth, sessions, file access, webhooks, secrets), transparent list of known weaker areas (no rate limiting, no virus scan on uploads, etc.), self-hoster hardening checklist
- **CLAUDE.md** — project-level conventions for AI coding assistants: stack rules, load-bearing architectural constraints, things-never-to-do, documentation responsibilities
- **backend/README.md** — backend-specific layout, setup, full env var table, endpoint reference, data model, migration pattern, storage service, common issues

## Voice

Mixed, per request: personal "Why I built this" paragraph in the main README only. Everything else is neutral and professional so contributors can scan it fast.

## Accuracy

Every doc is derived from the code as it is on `main` right now, not templates or guesses:

- Routes and models match `backend/app/routes/*` and `backend/app/models/*`
- The Dodo webhook HMAC description matches `backend/app/routes/webhooks.py` (Standard Webhooks spec, base64-decoded secret, `whsec_` prefix strip, constant-time compare)
- The PKCE OAuth flow description matches `backend/app/routes/auth.py`
- The CHANGELOG entries are grouped from real commits in the git log
- The env var tables were built from `.env.example`, `backend/.env.example`, and `backend/app/config.py`
- Cross-links point at real files (`docs/POSTHOG_EVENTS.md`, `docs/RAILWAY_DEPLOYMENT.md`, `docs/QUICKSTART.md`, `docs/ReadEz.postman_collection.json`) — all verified to exist

## Test plan

- [ ] Read README.md in the GitHub UI and confirm the intro voice feels right
- [ ] Skim ARCHITECTURE.md for any factual mistakes (routes, models, field names)
- [ ] Confirm the CHANGELOG feature groupings match how you remember shipping them
- [ ] Confirm the SECURITY.md "known weaker" section is accurate — flag anything I got wrong about current posture
- [ ] Confirm the CLAUDE.md rules match how you actually want AI assistants to behave in this repo
- [ ] Merge when happy

🤖 Generated with [Claude Code](https://claude.com/claude-code)