### PR TITLE
chore: hide paid-plan UI and fix static file serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ __pycache__/
 
 # Storage (user-uploaded books and thumbnails)
 backend/storage/
+.gstack/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,7 +116,8 @@ if STATIC_DIR.exists():
         response = await call_next(request)
         logger.info(f"Response status: {response.status_code}")
 
-        # If the response is 404 and it's not an API route, serve the SPA
+        # If the response is 404 and it's not an API route, try serving a
+        # real static file first, then fall back to the SPA index.html
         if response.status_code == 404:
             # Skip API routes and health check
             api_prefixes = ["/health", "/auth", "/books", "/progress", "/subscription", "/payments", "/feedback", "/webhooks", "/assets"]
@@ -124,6 +125,22 @@ if STATIC_DIR.exists():
             logger.info(f"Is API route: {is_api_route}")
 
             if not is_api_route:
+                # Try to serve the requested path as a real file from the
+                # static directory (e.g. /screenshots/library.png, /robots.txt,
+                # /sitemap.xml, /book-icon.svg). This is needed because only
+                # /assets is mounted as StaticFiles above.
+                safe_path = path.lstrip("/")
+                if safe_path:
+                    static_root = STATIC_DIR.resolve()
+                    requested_file = (STATIC_DIR / safe_path).resolve()
+                    try:
+                        requested_file.relative_to(static_root)
+                        if requested_file.is_file():
+                            logger.info(f"Serving static file for path: {path}")
+                            return FileResponse(str(requested_file))
+                    except ValueError:
+                        logger.warning(f"Rejected path traversal attempt: {path}")
+
                 index_path = STATIC_DIR / "index.html"
                 if index_path.exists():
                     logger.info(f"Serving SPA index.html for path: {path}")

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -226,7 +226,7 @@ function Auth({ children }) {
       {isLibraryPage && (
         <div className="absolute top-4 right-4 flex items-center gap-3 z-50">
           {/* Upgrade Button - Only show for free tier */}
-          {tier === 'free' && (
+          {false && tier === 'free' && (
             <Link
               to="/#pricing"
               onClick={() => trackEvent('upgrade_button_clicked', { location: 'header' })}

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -120,9 +120,11 @@ function Landing() {
             <a href="#readez-in-action" onClick={() => trackEvent('landing_section_scrolled', { section: 'readez-in-action' })} className="text-gray-700 hover:text-blue-600 transition-colors font-medium cursor-pointer">
               ReadEz in Action
             </a>
-            <a href="#pricing" onClick={() => trackEvent('landing_section_scrolled', { section: 'pricing' })} className="text-gray-700 hover:text-blue-600 transition-colors font-medium cursor-pointer">
-              Pricing
-            </a>
+            {false && (
+              <a href="#pricing" onClick={() => trackEvent('landing_section_scrolled', { section: 'pricing' })} className="text-gray-700 hover:text-blue-600 transition-colors font-medium cursor-pointer">
+                Pricing
+              </a>
+            )}
             {isAuthenticated && (
               <Link to="/library" className="text-gray-700 hover:text-blue-600 transition-colors font-medium cursor-pointer">
                 Library
@@ -335,6 +337,7 @@ function Landing() {
       </section>
 
       {/* Pricing Section */}
+      {false && (
       <section id="pricing" className="bg-white py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
@@ -517,6 +520,7 @@ function Landing() {
           </div>
         </div>
       </section>
+      )}
 
       {/* CTA Section */}
       <section className="bg-blue-600 py-16">

--- a/src/pages/Library.jsx
+++ b/src/pages/Library.jsx
@@ -247,7 +247,7 @@ function Library() {
         {/* Header with title and subscription badge */}
         <div className="flex items-center gap-3 mb-8">
           <h1 className="text-3xl font-bold">My Library</h1>
-          {!subscriptionLoading && <SubscriptionBadge tier={tier} />}
+          {false && !subscriptionLoading && <SubscriptionBadge tier={tier} />}
         </div>
 
         {/* Upload area */}


### PR DESCRIPTION
## Summary
- Present ReadEz as a purely free, open-source product by hiding every UI surface that signals a paid tier (pricing section, upgrade CTA, plan badge)
- Keep the underlying subscription machinery intact so this is trivially reversible — all hides are `{false && ...}` gates, no deletions
- Fix a backend bug where top-level static files (robots.txt, sitemap.xml, screenshots, etc.) were falling through to the SPA shell instead of being served

## Changes

### Hide paid-plan UI (frontend)
- Landing page: removed the "Pricing" nav link and the entire "Simple, Transparent Pricing" section with Free/Pro/Plus cards. Page now flows Hero → Features → ReadEz in Action → "Ready to Start Reading?" CTA → Open Source.
- Library header overlay: hidden the "Upgrade" button that was shown to free-tier users
- Library page: hidden the `SubscriptionBadge` next to "My Library"
- Components themselves (`SubscriptionBadge`, `SubscriptionModal`, `useSubscription`, `subscriptionHelpers`) are untouched and still importable
- Backend subscription routes, Dodo webhook verification, and `/subscription/success|cancel` pages are untouched — just no longer linked from the UI
- Reverting is one find-and-replace per gate

### Backend static-file serving fix
- `backend/app/main.py` SPA fallback middleware now attempts to serve a real file from the static directory before falling back to `index.html`
- Previously only `/assets` was mounted as StaticFiles, so requests for `/robots.txt`, `/sitemap.xml`, `/screenshots/*`, `/book-icon.svg`, etc. were returning the SPA HTML shell instead of the actual file
- Path traversal is blocked via `relative_to` check against the resolved static root

### Chore
- `.gitignore`: ignore local `.gstack/` tooling directory

## Verification
- `npm run build` — green (3.25s)
- `npm test` — 50 pass / 6 fail; confirmed via `git stash` that the 6 failures exist on pristine main, zero new regressions
- Landing page verified in the browser at `http://localhost:5173`: nav shows only Home / Features / ReadEz in Action, no "Pricing" link, no pricing section, no upgrade copy anywhere on the page

---
Generated with [Claude Code](https://claude.com/claude-code)